### PR TITLE
Treat `fields` argument as additional fields

### DIFF
--- a/R/db.R
+++ b/R/db.R
@@ -11,16 +11,15 @@ get_db_file <- function(dir) {
 
 get_fields <- function(fields) {
   if (is.null(fields)) {
-    fields <- unique(c(
-      ("tools" %:::% ".get_standard_repository_db_fields")(),
-      "MD5sum",
+    fields <- c(
       "SystemRequirements",
       "Built",
       "Published"
-    ))
+    )
   }
+  standard_fields <- ("tools" %:::% ".get_standard_repository_db_fields")()
 
-  unique(c(fields, "File"))
+  unique(c("MD5sum", standard_fields, fields, "File"))
 }
 
 db_env <- new.env()


### PR DESCRIPTION
... like tools::write_PACKAGES().

``` r
withr::with_tempdir({
  download.packages("cranlike", ".")
  cranlike::update_PACKAGES(fields = c("Title", "Description"))
  read.dcf("PACKAGES")
})
#>      MD5sum                             Package    Version
#> [1,] "542dc9381840cfd998fecd57fc14f560" "cranlike" "1.0.3"
#>      Imports                                               
#> [1,] "DBI, debugme, desc (>= 1.1.0), RSQLite, tools, utils"
#>      Suggests                              License      NeedsCompilation
#> [1,] "covr, mockery, testthat, withr, zip" "GPL (>= 2)" "no"            
#>      Title                               
#> [1,] "Tools for 'CRAN'-Like Repositories"
#>      Description                                                          
#> [1,] "A set of functions to manage 'CRAN'-like repositories\nefficiently."
#>      File                    Filesize
#> [1,] "cranlike_1.0.3.tar.gz" "12493"
```

Fixes #14.